### PR TITLE
Simple Todo List CLI App

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["todo-cli"]
+resolver = "2"

--- a/todo-cli/Cargo.toml
+++ b/todo-cli/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "todo-cli"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4.1", features = ["derive"] }

--- a/todo-cli/src/main.rs
+++ b/todo-cli/src/main.rs
@@ -1,0 +1,51 @@
+use clap::{Parser, Subcommand};
+use std::fs::{read_to_string, OpenOptions};
+use std::io::Write;
+
+#[derive(Parser)]
+#[command(name = "Todo")]
+#[command(about = "A simple to-do list CLI app")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    Add {
+        #[arg()]
+        task: String,
+    },
+    List,
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    match &cli.command {
+        Commands::Add { task } => add_task(task),
+        Commands::List => list_tasks(),
+    }
+}
+
+fn add_task(task: &str) {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .open("todo.txt")
+        .expect("Failed to open file");
+
+    writeln!(file, "{}", task).expect("Failed to write to file");
+    println!("Added task: {}", task);
+}
+
+fn list_tasks() {
+    let content = read_to_string("todo.txt").expect("Failed to read file");
+
+    if content.is_empty() {
+        println!("No tasks found.");
+    } else {
+        for (index, task) in content.lines().enumerate() {
+            println!("{}: {}", index, task);
+        }
+    }
+}


### PR DESCRIPTION
Simple CLI app to manage a to-do list.

There are two commands available:
  - `add <task>`: Add a new task to the list.
  - `list`: List all tasks in the list.

Requirements:
  - Adding a task should append it to a file called `todo.txt`
  - Listing tasks should read the file and print each task with an index.

Example Usages

```
$ todo-cli add "Buy groceries
Added task: Buy groceries

$ todo-cli list
1: Buy groceries

$ todo-cli add "Clean the house"
Added task: Clean the house

$ todo-cli list
1: Buy groceries
2: Clean the house
```